### PR TITLE
Cache bert

### DIFF
--- a/get-started/walkthrough.ipynb
+++ b/get-started/walkthrough.ipynb
@@ -595,13 +595,13 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Now we are ready to train.\n",
+    "### Loading Precompiled Executable\n",
     "\n",
-    "In the next steps, your PyTorch source code is compiled into a graph program which dictates how the program can be executed on the IPU hardware. In order to save time, pre-compiled execution graph can be loaded so the model doesn't get recompiled. \n",
+    "In order to save time, pre-compiled execution graph can be loaded so the model doesn't get recompiled. \n",
     "\n",
     "You  can see the documentation on [Precompilation and Caching](https://docs.graphcore.ai/projects/poptorch-user-guide/en/latest/overview.html#precompilation-and-caching) to know how it works.\n",
     "\n",
-    "For this example, we have made a pre-compiled executables available and will load them into the `exe_cache` folder in order to skip compilation and proceed straight to running your training or evaluation. \n",
+    "For this example, we have made pre-compiled executables available and will load them into the `exe_cache` folder in order to skip compilation and proceed straight to running your training or evaluation. \n",
     "\n",
     "Note that the VM has limited local storage, your cache directory might also grow large and fill your storage as you recompile so manage your storage accordingly. We recommend changing output paths to `/tmp` so it gets flushed upon shutdown. "
    ]
@@ -616,6 +616,15 @@
     "# When present, expect Graph Compilation in the next step to take only a few seconds.\n",
     "!mkdir -p ./exe_cache\n",
     "!ln -s /graphcore/exe_cache/* ./exe_cache/"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "In the next steps, your PyTorch source code is compiled into a graph program which dictates how the program can be executed on the IPU hardware if there's no precompiled executable found. This process can take a few minutes, especially for more complex models.\n",
+    "\n",
+    "Now you are ready to train."
    ]
   },
   {

--- a/notebook-tutorials/introduction_to_optimum_graphcore.ipynb
+++ b/notebook-tutorials/introduction_to_optimum_graphcore.ipynb
@@ -1455,7 +1455,7 @@
     "# Load the training executable to skip recompilation. \n",
     "# When present, expect Graph Compilation in the next step to take only a few seconds.\n",
     "!mkdir -p ./exe_cache\n",
-    "!ln -s /graphcore/exe_cache/* ./exe_cache/"
+    "!ln -s /graphcore/exe_cache/* /tmp/exe_cache/"
    ]
   },
   {

--- a/notebook-tutorials/introduction_to_optimum_graphcore.ipynb
+++ b/notebook-tutorials/introduction_to_optimum_graphcore.ipynb
@@ -1432,6 +1432,42 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Loading Precompiled Executable\n",
+    "\n",
+    "In order to save time, pre-compiled execution graph can be loaded so the model doesn't get recompiled. In the next steps, your PyTorch source code is compiled into a graph program which dictates how the program can be executed on the IPU hardware if there's no precompiled executable available. \n",
+    "\n",
+    "You  can see the documentation on [Precompilation and Caching](https://docs.graphcore.ai/projects/poptorch-user-guide/en/latest/overview.html#precompilation-and-caching) to know how it works.\n",
+    "\n",
+    "For this example, we have made pre-compiled executables available and will load them into the `exe_cache` folder in order to skip compilation and proceed straight to running your training or evaluation. \n",
+    "\n",
+    "Note that the VM has limited local storage, your cache directory might also grow large and fill your storage as you recompile so manage your storage accordingly. We recommend changing output paths to `/tmp` so it gets flushed upon shutdown. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Load the training executable to skip recompilation. \n",
+    "# When present, expect Graph Compilation in the next step to take only a few seconds.\n",
+    "!mkdir -p ./exe_cache\n",
+    "!ln -s /graphcore/exe_cache/* ./exe_cache/"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "In the next step, your PyTorch source code is compiled into a graph program which dictates how the program can be executed on the IPU hardware if there's no precompiled executable found. This process can take a few minutes, especially for more complex models.\n",
+    "\n",
+    "Now you are ready to train."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 26,
    "id": "336f77b2",


### PR DESCRIPTION
What this does:
- ensure 'exe_cache' is available and writeable
- load '.popef' files from the read-only cache
- this will allow PopTorch to find the pre-compiled executables so graph won't need to recompile