### PR TITLE
Fix cache intro

### DIFF
--- a/notebook-tutorials/introduction_to_optimum_graphcore.ipynb
+++ b/notebook-tutorials/introduction_to_optimum_graphcore.ipynb
@@ -1491,7 +1491,7 @@
     "# Load the training executable to skip recompilation. \n",
     "# When present, expect Graph Compilation in the next step to take only a few seconds.\n",
     "!mkdir -p /tmp/exe_cache\n",
-    "!ln -s /graphcore/exe_cache/* /tmp/exe_cache"
+    "!ln -s /graphcore/exe_cache/* /tmp/exe_cache/"
    ]
   },
   {

--- a/notebook-tutorials/introduction_to_optimum_graphcore.ipynb
+++ b/notebook-tutorials/introduction_to_optimum_graphcore.ipynb
@@ -1490,8 +1490,8 @@
    "source": [
     "# Load the training executable to skip recompilation. \n",
     "# When present, expect Graph Compilation in the next step to take only a few seconds.\n",
-    "!mkdir -p ./exe_cache\n",
-    "!ln -s /graphcore/exe_cache/* ./exe_cache/"
+    "!mkdir -p /tmp/exe_cache\n",
+    "!ln -s /graphcore/exe_cache/* /tmp/exe_cache"
    ]
   },
   {

--- a/notebook-tutorials/introduction_to_optimum_graphcore.ipynb
+++ b/notebook-tutorials/introduction_to_optimum_graphcore.ipynb
@@ -1491,7 +1491,7 @@
     "# Load the training executable to skip recompilation. \n",
     "# When present, expect Graph Compilation in the next step to take only a few seconds.\n",
     "!mkdir -p ./exe_cache\n",
-    "!ln -s /graphcore/exe_cache/* /tmp/exe_cache/"
+    "!ln -s /graphcore/exe_cache/* ./exe_cache/"
    ]
   },
   {

--- a/notebook-tutorials/text_classification.ipynb
+++ b/notebook-tutorials/text_classification.ipynb
@@ -1143,7 +1143,7 @@
     "# Load the training executable to skip recompilation. \n",
     "# When present, expect Graph Compilation in the next step to take only a few seconds.\n",
     "!mkdir -p /tmp/exe_cache\n",
-    "!ln -s /graphcore/exe_cache/* /tmp/exe_cache"
+    "!ln -s /graphcore/exe_cache/* /tmp/exe_cache/"
    ]
   },
   {

--- a/notebook-tutorials/text_classification.ipynb
+++ b/notebook-tutorials/text_classification.ipynb
@@ -1121,6 +1121,33 @@
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Loading Precompiled Executable\n",
+    "\n",
+    "In order to save time, pre-compiled execution graph can be loaded so the model doesn't get recompiled. In the next steps, your PyTorch source code is compiled into a graph program which dictates how the program can be executed on the IPU hardware if there's no precompiled executable available. \n",
+    "\n",
+    "You  can see the documentation on [Precompilation and Caching](https://docs.graphcore.ai/projects/poptorch-user-guide/en/latest/overview.html#precompilation-and-caching) to know how it works.\n",
+    "\n",
+    "For this example, we have made pre-compiled executables available and will load them into the `exe_cache` folder in order to skip compilation and proceed straight to running your training or evaluation. \n",
+    "\n",
+    "Note that the VM has limited local storage, your cache directory might also grow large and fill your storage as you recompile so manage your storage accordingly. We recommend changing output paths to `/tmp` so it gets flushed upon shutdown. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Load the training executable to skip recompilation. \n",
+    "# When present, expect Graph Compilation in the next step to take only a few seconds.\n",
+    "!mkdir -p /tmp/exe_cache\n",
+    "!ln -s /graphcore/exe_cache/* /tmp/exe_cache"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "metadata": {
     "id": "CdzABDVcIrJg"
    },


### PR DESCRIPTION
What this does:
- point to `/tmp/exe_cache` where `.poppef` file should be expected
- if executable is available, compilation is skipped and file is loaded in seconds