### PR TITLE
Pin optimum-graphcore version to <0.4 to work with 2.6 release sdk

### DIFF
--- a/get-started/requirements.txt
+++ b/get-started/requirements.txt
@@ -3,6 +3,6 @@ datasets
 torchvision==0.11.1
 transformers
 optimum
-optimum-graphcore
+optimum-graphcore<0.4
 matplotlib
 sklearn


### PR DESCRIPTION
The version of the 'optimum-graphcore' library used in the 'get-started' directory needs to be pinned to a version lower than 0.4 in order to work with the default 2.6 sdk, or the notebook will encounter errors during execution. 