### PR TITLE
Specify the test dataset revision to use the cached dataset

### DIFF
--- a/notebook-tutorials/wav2vec2/wav2vec2-inference-checkpoint.ipynb
+++ b/notebook-tutorials/wav2vec2/wav2vec2-inference-checkpoint.ipynb
@@ -182,7 +182,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "ds = load_dataset(\"librispeech_asr\", \"clean\", split=\"test\")"
+    "ds = load_dataset(\"librispeech_asr\", \"clean\", split=\"test\", cache_dir=\"/tmp/dataset_cache\", revision=\"7e19c6884208777b6bf648207ae6602c445b81d0\")"
    ]
   },
   {


### PR DESCRIPTION
Resolve dataset download error by specifying the revision of the cached dataset, similar to https://github.com/gradient-ai/Graphcore-HuggingFace/pull/26