### PR TITLE
Remove deprecated --ignore-errors flag

### DIFF
--- a/.gradient/automated-test.sh
+++ b/.gradient/automated-test.sh
@@ -42,7 +42,6 @@ run_tests(){
     mkdir -p ${LOG_FOLDER}
     cd /notebooks/
     python -m examples_utils platform_assessment --spec ${TEST_CONFIG_FILE} "${@:8}" \
-        --ignore-errors \
         --log-dir $LOG_FOLDER \
         --gc-monitor \
         --cloning-directory /tmp/clones \


### PR DESCRIPTION
Test script is broken by the change in examples-utils tag.