### PR TITLE
wait until source dataset dir is populated to create overlay

### DIFF
--- a/.gradient/prepare-datasets.sh
+++ b/.gradient/prepare-datasets.sh
@@ -5,8 +5,7 @@ symlink-public-resources() {
     target_dir=${2}
 
     # need to wait until the dataset has been mounted (async on Paperspace's end)
-    #while [ ! -d "${PUBLIC_DATASET_DIR}/exe_cache" ]
-    while [ ! -d ${public_source_dir} ]
+    while [ ! -d ${public_source_dir} ] || [ -z "$(ls -A ${public_source_dir})" ]
     do
         echo "Waiting for dataset "${public_source_dir}" to be mounted..."
         sleep 1


### PR DESCRIPTION
Updates our `prepare-datasets.sh` script (called by `setup.sh`) to wait for source dataset folders to be populated before creating the overlay. This is to resolve the issue where the overlay was created when the source directory was created, but not populated, and so the corresponding `/tmp` directory was empty, which led to the executable caches and datasets not being available for the jupyter notebooks. 

Tests:
Before this change, the /tmp folder would be missing caches for every 1/3-1/2 of the notebooks started. After the change, the /tmp folder is fully populated. 