### PR TITLE
add timeout to symlink while loop

### DIFF
--- a/.gradient/prepare-datasets.sh
+++ b/.gradient/prepare-datasets.sh
@@ -5,10 +5,17 @@ symlink-public-resources() {
     target_dir=${2}
 
     # need to wait until the dataset has been mounted (async on Paperspace's end)
-    while [ ! -d ${public_source_dir} ] || [ -z "$(ls -A ${public_source_dir})" ]
+    COUNTER=0
+    # set a timeout of 300s/5m for the while loop as a safety measure
+    while [ $COUNTER -lt 300 ] && ( [ ! -d ${public_source_dir} ] || [ -z "$(ls -A ${public_source_dir})" ] )
     do
         echo "Waiting for dataset "${public_source_dir}" to be mounted..."
         sleep 1
+        ((COUNTER++))
+        if [ $COUNTER -eq 300 ]; then
+            echo "Warning! Abandoning symlink - source Dataset ${public_source_dir} has not been mounted & populated after 5m."
+            return
+        fi
     done
 
     echo "Symlinking - ${public_source_dir} to ${target_dir}"

--- a/.gradient/prepare-datasets.sh
+++ b/.gradient/prepare-datasets.sh
@@ -1,31 +1,33 @@
-#!/bin/bash
+#! /usr/bin/env bash
+set -u
+set -o pipefail
 
 symlink-public-resources() {
     public_source_dir=${1}
     target_dir=${2}
 
     # need to wait until the dataset has been mounted (async on Paperspace's end)
-    COUNTER=0
-    # set a timeout of 300s/5m for the while loop as a safety measure
-    while [ $COUNTER -lt 300 ] && ( [ ! -d ${public_source_dir} ] || [ -z "$(ls -A ${public_source_dir})" ] )
+    # we check that the dataset dir exists and is populated/non-empty
+    # set a timeout of 300s/5m for the loop as a safety measure
+    local -i COUNTER=0
+    until (( COUNTER == 300 )) ||
+            [[ -d "${public_source_dir}" && (( $(
+                find "${public_source_dir}" -mindepth 1 -maxdepth 1 -print | wc -l
+            ) > 0 )) ]]
     do
         echo "Waiting for dataset "${public_source_dir}" to be mounted..."
         sleep 1
         ((COUNTER++))
-        if [ $COUNTER -eq 300 ]; then
-            echo "Warning! Abandoning symlink - source Dataset ${public_source_dir} has not been mounted & populated after 5m."
-            return
-        fi
     done
+
+    # exit the function if the dataset doesn't exit
+    if (( COUNTER == 300 )); then
+        echo "Warning! Abandoning symlink - source Dataset ${public_source_dir} has not been mounted & populated after 5m."
+        return 1
+    fi
 
     echo "Symlinking - ${public_source_dir} to ${target_dir}"
 
-    # Make sure it exists otherwise you'll copy your current dir
-    # mkdir -p ${public_source_dir}
-    # cd ${public_source_dir}
-    # find -type d -exec mkdir -p "${target_dir}/{}" \;
-    # find -type f -not -name "*.lock" -print0 | xargs -0 -P 50 -I {} sh -c "cp -sP \"${PWD}/{}\" \"${target_dir}/{}\""
-    # cd -
     mkdir -p ${target_dir}
     workdir="/fusedoverlay/workdirs/${public_source_dir}"
     upperdir="/fusedoverlay/upperdir/${public_source_dir}"
@@ -60,8 +62,8 @@ python -m pip install "optimum-graphcore>=0.5, <0.6"
 
 echo "Finished running setup.sh."
 # Run automated test if specified
-if [[ "$1" == "test" ]]; then
+if [[ "${1:-}" == "test" ]]; then
     bash /notebooks/.gradient/automated-test.sh "${@:2}"
-elif [[ "$2" == "test" ]]; then
+elif [[ "${2:-}" == "test" ]]; then
     bash /notebooks/.gradient/automated-test.sh "${@:3}"
 fi


### PR DESCRIPTION
adds a 5 minute timeout to the symlinking while loop. In the unexpected case where the dataset doesn't get mounted, or remains empty, then instead of looping forever, we terminate the loop after 5 minutes. Datasets are usually mounted within a minute, so I thought 5 minutes would be a reasonable timeout, but please suggest a different value if desired. 

Testing performed:
Edited the script to attempt to symlink a non-existing dataset. We were 'waiting for dataset..' for 5 minutes and then successfully broke out of the loop and proceeded with the rest of the script. Other datasets that existed were symlinked/overlays created as usual. 