### PR TITLE
added option for selecting examples-utils revision

### DIFF
--- a/.gradient/automated-test.sh
+++ b/.gradient/automated-test.sh
@@ -10,9 +10,12 @@
 # 3: Version ID
 # 4: Either the runtime in which we are running or 'upload-reports'
 # 5: Folder in which to save/look for tar.gz report archives
-# 6: Examples utils spec file to process and benchmark 
+# 6: Examples utils spec file to process and benchmark
 # 7: Huggingface token
-# @:8 other arguments are passed to the `examples_utils platform_assesment` command
+# 8: examples-utils revision
+# @:9 other arguments are passed to the `examples_utils platform_assesment` command
+
+set -x
 
 upload_report() {
     # Uploads files to a gradient dataset
@@ -35,24 +38,29 @@ run_tests(){
     # set variable matching the standard Paperspace entry point
     export PIP_DISABLE_PIP_VERSION_CHECK=1
 
-
     export VIRTUAL_ENV="/some/fake/venv/GC-automated-paperspace-test-${4}"
     LOG_FOLDER="${5}/log_${4}_$(date +'%Y-%m-%d-%H_%M_%S')"
     TEST_CONFIG_FILE="${6}"
     mkdir -p ${LOG_FOLDER}
     cd /notebooks/
-    python -m examples_utils platform_assessment --spec ${TEST_CONFIG_FILE} "${@:8}" \
+    python -m examples_utils platform_assessment --spec ${TEST_CONFIG_FILE} "${@:9}" \
         --log-dir $LOG_FOLDER \
         --gc-monitor \
         --cloning-directory /tmp/clones \
-        --additional-metrics 
+        --additional-metrics
+
     tar -czvf "${LOG_FOLDER}.tar.gz" ${LOG_FOLDER}
     echo "PAPERSPACE-AUTOMATED-TESTING: Testing complete"
 }
 # Prep the huggingface token
 export HUGGING_FACE_HUB_TOKEN=${7}
+if [ "${8}" == "unset" ]; then
+    EXAMPLES_UTILS_REV=latest_stable
+else
+    EXAMPLES_UTILS_REV=${8}
+fi
 
-python -m pip install "examples-utils[jupyter] @ git+https://github.com/graphcore/examples-utils@latest_stable"
+python -m pip install "examples-utils[jupyter] @ git+https://github.com/graphcore/examples-utils@${EXAMPLES_UTILS_REV}"
 python -m pip install gradient
 # In sh single equal is needed for string compare.
 if [ "${4}" = "upload-reports" ]

--- a/.gradient/prepare-datasets.sh
+++ b/.gradient/prepare-datasets.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -x
+
 symlink-public-resources() {
     public_source_dir=${1}
     target_dir=${2}


### PR DESCRIPTION
I would like to be able to indicate what examples-utils will be used when I invoke testing from paperspace-automation scripts. Currently, this is hardcoded to latest_stable. Exposing this as an argument allows for easy testing on changes in examples-utils.

I would like to enable tracing what prepare-datasets.sh and automated-test.sh are doing.
To do this, I added set -x option to these bash scripts.
