### PR TITLE
Pin optimum-graphcore version for stable diffusion

### DIFF
--- a/stable-diffusion/requirements.txt
+++ b/stable-diffusion/requirements.txt
@@ -1,3 +1,3 @@
 diffusers[torch]==0.9
-optimum-graphcore
+optimum-graphcore>=0.5, <0.6
 matplotlib


### PR DESCRIPTION
Mainly intended so ongoing Stable Diffusion work can be landed to optimum-graphcore which may include breaking API
changes.