### PR TITLE
Raise error if gc-monitor takes more than 10s

### DIFF
--- a/.gradient/available_ipus.py
+++ b/.gradient/available_ipus.py
@@ -1,11 +1,13 @@
 # Copyright (c) 2022 Graphcore Ltd. All rights reserved.
 import subprocess
 import json
-
-j = subprocess.check_output(['gc-monitor', '-j'])
-data = json.loads(j)
-num_ipuMs = len(data["cards"])
-num_ipus = 4 * num_ipuMs
-
+try:
+    j = subprocess.check_output(['gc-monitor', '-j'], timeout=10)
+    data = json.loads(j)
+    num_ipuMs = len(data["cards"])
+    num_ipus = 4 * num_ipuMs
+except subprocess.TimeoutExpired as err:
+    print(f"{err}")
+    num_ipus = 4
 # to be captured as a variable in the bash script that calls this python script
 print(num_ipus)

--- a/.gradient/available_ipus.py
+++ b/.gradient/available_ipus.py
@@ -1,13 +1,22 @@
 # Copyright (c) 2022 Graphcore Ltd. All rights reserved.
 import subprocess
 import json
+import warnings
+import os
+
 try:
     j = subprocess.check_output(['gc-monitor', '-j'], timeout=10)
     data = json.loads(j)
     num_ipuMs = len(data["cards"])
     num_ipus = 4 * num_ipuMs
 except subprocess.TimeoutExpired as err:
-    print(f"{err}")
-    num_ipus = 4
+    num_ipus = 0
+    print(num_ipus)
+    nb_id = os.getenv("PAPERSPACE_METRIC_WORKLOAD_ID", "unknown")
+    raise OSError(
+        "Connection to IPUs timed-out. This error indicates a problem with the "
+        "hardware you are running on. Please contact Paperspace Support referencing"
+        f" the Notebook ID: {nb_id}"
+    ) from err
 # to be captured as a variable in the bash script that calls this python script
 print(num_ipus)

--- a/setup.sh
+++ b/setup.sh
@@ -18,8 +18,9 @@ if [[ "${DETECTED_NUMBER_OF_IPUS}" == "0" ]]; then
     echo "                         ERROR  DETECTED"
     echo "=============================================================================="
     echo "Connection to IPUs timed-out. This error indicates a problem with the "
-    echo "hardware you are running on. Please contact Paperspace Support referencing"
-    echo " the Notebook ID: ${PAPERSPACE_METRIC_WORKLOAD_ID:-unknown}"
+    echo "hardware you are running on. Please contact Paperspace Support at "
+    echo " https://docs.paperspace.com/contact-support/ "
+    echo " referencing the Notebook ID: ${PAPERSPACE_METRIC_WORKLOAD_ID:-unknown}"
     echo "=============================================================================="
     exit -1
 fi

--- a/setup.sh
+++ b/setup.sh
@@ -13,6 +13,16 @@ else
     IPU_ARG=${1:-"${DETECTED_NUMBER_OF_IPUS}"}
 fi
 echo "Graphcore setup - Detected ${DETECTED_NUMBER_OF_IPUS} IPUs"
+if [[ "${DETECTED_NUMBER_OF_IPUS}" == "0" ]]; then
+    echo "=============================================================================="
+    echo "                         ERROR  DETECTED"
+    echo "=============================================================================="
+    echo "Connection to IPUs timed-out. This error indicates a problem with the "
+    echo "hardware you are running on. Please contact Paperspace Support referencing"
+    echo " the Notebook ID: ${PAPERSPACE_METRIC_WORKLOAD_ID:-unknown}"
+    echo "=============================================================================="
+    exit -1
+fi
 
 export NUM_AVAILABLE_IPU=${IPU_ARG}
 export GRAPHCORE_POD_TYPE="pod${IPU_ARG}"


### PR DESCRIPTION
gc-monitor is causing our notebooks to fail on startup, because it is running very slowly in the command in the entry of the notebook. This hang is a symptom of a deeper issue with the state of the hardware. We surface that problem to the user in an obvious error message asking them to report it to support.